### PR TITLE
Fix: Don’t abort Amazon load on certain $ amounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ dist/
 webdriver-browser-profiles/
 
 # App configuration file
-default.json
+config/default.json5
 
 # Visual Studio files
 /.vs/slnx.sqlite

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,11 +10,10 @@
             "name": "Launch Program",
             "program": "${workspaceFolder}\\src\\index.ts",
             "preLaunchTask": "tsc: build - tsconfig.json",
-            "outFiles": [
-                "${workspaceFolder}/dist/**/*.js"
-            ],
-            "outputCapture": "std",
-            "internalConsoleOptions": "openOnSessionStart"
+            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+            "outputCapture": "std",             // For winston output
+            "console": "integratedTerminal",    // For inquirer support
+            "cwd": "${workspaceFolder}"         // Needed once we set 'console'
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,10 @@
 {
-    "tslint.configFile": "./tslint/tslint.yaml",
-    "javascript.format.placeOpenBraceOnNewLineForControlBlocks": true, 
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "files.trimTrailingWhitespace": true,
+    "javascript.format.placeOpenBraceOnNewLineForControlBlocks": true,
     "javascript.format.placeOpenBraceOnNewLineForFunctions": true,
     "typescript.format.placeOpenBraceOnNewLineForControlBlocks": true,
-    "typescript.format.placeOpenBraceOnNewLineForFunctions": true
+    "typescript.format.placeOpenBraceOnNewLineForFunctions": true,
+    "tslint.configFile": "./tslint/tslint.yaml",
 }

--- a/config/default-example.json5
+++ b/config/default-example.json5
@@ -8,14 +8,14 @@
       {
         description: "Acme Bank Gold Card",
         cardNumber: "4111111111111111",
-        reloadAmount: 10.0,
+        reloadAmount: 10.00,
         enabled: false,
         reloadTimes: 1
       },
       {
         description: "Acme Bank Platinum Card",
         cardNumber: "5500000000000004",
-        reloadAmount: 10.0,
+        reloadAmount: 10.00,
         enabled: true,
         reloadTimes: 1
       }

--- a/config/default-example2.json5
+++ b/config/default-example2.json5
@@ -8,14 +8,14 @@
       {
         description: "Acme Bank Gold Card",
         cardNumber: "4111111111111111",
-        reloadAmount: 10.0,
+        reloadAmount: 10.00,
         enabled: true,
         reloadTimes: 1
       },
       {
         description: "Acme Bank Platinum Card",
         cardNumber: "5500000000000004",
-        reloadAmount: 10.0,
+        reloadAmount: 10.00,
         cardholderName: 'JOHN SMITH',
         expirationMonth: 12,
         expirationYear: 2022,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-transact",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24,6 +24,34 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@hapi/address": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+    },
+    "@hapi/hoek": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+      "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+    },
+    "@hapi/joi": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.3.tgz",
+      "integrity": "sha512-z6CesJ2YBwgVCi+ci8SI8zixoj8bGFn/vZb9MBPbSyoxsS2PnWYjHcyTM17VLK6tx64YVK38SDIh10hJypB+ig==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.0.tgz",
+      "integrity": "sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==",
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      }
+    },
     "@types/accounting": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/accounting/-/accounting-0.4.1.tgz",
@@ -38,20 +66,39 @@
         "@types/node": "*"
       }
     },
+    "@types/hapi__joi": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-15.0.1.tgz",
+      "integrity": "sha512-uqH3kTO1nrhe+Pbq+dQKrulrfscRPjFZNv9UWA3FupJZBHw+miT7yiV6C8A80YLnn0o6zbgTProncBb3d7QohA==",
+      "dev": true,
+      "requires": {
+        "@types/hapi__joi": "*"
+      }
+    },
+    "@types/inquirer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-6.0.3.tgz",
+      "integrity": "sha512-lBsdZScFMaFYYIE3Y6CWX22B9VeY2NerT1kyU2heTc3u/W6a+Om6Au2q0rMzBrzynN0l4QoABhI0cbNdyz6fDg==",
+      "dev": true,
+      "requires": {
+        "@types/through": "*",
+        "rxjs": "^6.4.0"
+      }
+    },
     "@types/json5": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.30.tgz",
       "integrity": "sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA=="
     },
     "@types/luxon": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.13.0.tgz",
-      "integrity": "sha512-XmDiRVoJWgVdqX9x1a/GU4p9bSgZY7q8SOyMLs3fx1AdQcxLYAPIt/jfZm2e+PBVRWuEx1FqYNJ37kBZ53TMqA=="
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.15.1.tgz",
+      "integrity": "sha512-SOGSpxsAoR+pHLev7oFGbQ4mZCmfcmYY2xsv2+/UeEG2rcJA30k5NVux3cW9rgTe2EVtrqFG+KtMs6ERZsTGKA=="
     },
     "@types/node": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
-      "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
+      "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw=="
     },
     "@types/selenium-webdriver": {
       "version": "4.0.0",
@@ -62,6 +109,15 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/table/-/table-4.0.5.tgz",
       "integrity": "sha512-M/e/pWOWjm8X/fu8I9eOhc/ww1RsUG1yOr/G3vgdBwVFmfnMiqCRIiEKpDZdscNNCzr/kAAzuTNqGUH1uAk/qQ=="
+    },
+    "@types/through": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
+      "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "accounting": {
       "version": "0.4.1",
@@ -92,10 +148,15 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+    },
     "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -226,6 +287,11 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
@@ -242,6 +308,19 @@
         "request": "^2.88.0",
         "tcp-port-used": "^1.0.1"
       }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "color": {
       "version": "3.0.0",
@@ -554,6 +633,16 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
     "extract-zip": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
@@ -597,6 +686,14 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -807,6 +904,14 @@
         }
       }
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -825,6 +930,26 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "inquirer": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      }
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -866,6 +991,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -1055,9 +1185,9 @@
       }
     },
     "luxon": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.13.2.tgz",
-      "integrity": "sha512-U7i2AE+/VWeB8PZZkIeEcxJCZvBA8LegCHufaIFYx3qRQdw2UJw3fuaL/Fqi9Q+2MeFYu+gYqIzr5hWOvAMHBQ=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.15.0.tgz",
+      "integrity": "sha512-HIpK4zIonObWHj9UC80ElykmM/0jTuuXcbPYBYbDGZ3Cq2bL9rACcmppoc6zm5JnmHpnK5bRMIp8/+ei4O0y2Q=="
     },
     "mime-db": {
       "version": "1.40.0",
@@ -1071,6 +1201,11 @@
       "requires": {
         "mime-db": "1.40.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1115,15 +1250,20 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
     "node-status-codes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
     },
     "nodemailer": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.1.1.tgz",
-      "integrity": "sha512-/x5MRIh56VyuuhLfcz+DL2SlBARpZpgQIf2A4Ao4hMb69MHSgDIMPwYmFwesGT1lkRDZ0eBSoym5+JoIZ3N+cQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.2.1.tgz",
+      "integrity": "sha512-TagB7iuIi9uyNgHExo8lUDq3VK5/B0BpbkcjIgNvxbtVrjNqq0DwAOTuzALPVkK76kMhTSzIgHqg8X1uklVs6g==",
       "dev": true
     },
     "oauth-sign": {
@@ -1148,6 +1288,14 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -1233,9 +1381,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -1298,12 +1446,21 @@
       }
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
+      }
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
@@ -1312,6 +1469,22 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "requires": {
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -1351,9 +1524,9 @@
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true
     },
     "set-immediate-shim": {
@@ -1375,6 +1548,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -1429,13 +1607,22 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -1452,6 +1639,13 @@
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "requires": {
         "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        }
       }
     },
     "supports-color": {
@@ -1463,14 +1657,26 @@
       }
     },
     "table": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.3.3.tgz",
-      "integrity": "sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
+      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
       "requires": {
         "ajv": "^6.9.1",
         "lodash": "^4.17.11",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
       }
     },
     "tar": {
@@ -1516,10 +1722,23 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
     "timed-out": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
       "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "tough-cookie": {
       "version": "2.4.3",
@@ -1545,13 +1764,12 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.16.0.tgz",
-      "integrity": "sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.17.0.tgz",
+      "integrity": "sha512-pflx87WfVoYepTet3xLfDOLDm9Jqi61UXIKePOuca0qoAZyrGWonDG9VTbji58Fy+8gciUn8Bt7y69+KEVjc/w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1560,7 +1778,7 @@
         "commander": "^2.12.1",
         "diff": "^3.2.0",
         "glob": "^7.1.1",
-        "js-yaml": "^3.13.0",
+        "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
@@ -1627,9 +1845,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw=="
     },
     "unzip-response": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-transact",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Completes transactions for specified amounts for a list of accounts.",
   "main": "dist/index.js",
   "scripts": {
@@ -19,29 +19,33 @@
     "tsc": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@hapi/joi": "^15.0.3",
     "@types/accounting": "^0.4.1",
     "@types/json5": "0.0.30",
-    "@types/luxon": "^1.13.0",
-    "@types/node": "^12.0.2",
+    "@types/luxon": "^1.15.1",
+    "@types/node": "^12.0.4",
     "@types/selenium-webdriver": "^4.0.0",
     "@types/table": "^4.0.5",
     "accounting": "^0.4.1",
     "chalk": "^2.4.2",
     "chromedriver": "latest",
     "geckodriver": "latest",
+    "inquirer": "^6.3.1",
     "json5": "^2.1.0",
-    "luxon": "^1.13.2",
+    "luxon": "^1.15.0",
     "selenium-webdriver": "3.6",
-    "table": "^5.3.3",
-    "typescript": "3.4",
+    "table": "^5.4.0",
+    "typescript": "^3.5.1",
     "winston": "3.2"
   },
   "devDependencies": {
     "@types/chromedriver": "latest",
+    "@types/hapi__joi": "^15.0.1",
+    "@types/inquirer": "^6.0.3",
     "cross-conf-env": "^1.1.2",
     "html-to-text": "^5.1.1",
-    "nodemailer": "^6.1.1",
-    "tslint": "^5.16.0",
+    "nodemailer": "^6.2.1",
+    "tslint": "^5.17.0",
     "tslint-eslint-rules": "^5.4.0"
   },
   "license": "GPL-3.0",

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -6,7 +6,7 @@
 import "chromedriver";
 import "geckodriver";
 import { Builder, Capabilities, ThenableWebDriver } from "selenium-webdriver";
-import { Options } from "selenium-webdriver/chrome";
+import { Options as ChromeOptions } from "selenium-webdriver/chrome";
 
 import { logger } from "./logger";
 
@@ -16,42 +16,36 @@ export class Browser
 {
 	public readonly driver: ThenableWebDriver;
 
-	public constructor(browserType: BrowserType, startingURL: URL, vpn: boolean = false)
+	public constructor(startingURL: URL, browserType: BrowserType = "chrome", vpn: boolean = false)
 	{
-		logger.debug(`Building a new ${browserType} browser (${startingURL.hostname})`);
+		const chromeCapabilities: Capabilities = Capabilities.chrome();
+		const chromeOptions: ChromeOptions = new ChromeOptions();
 
-		if (browserType === "chrome")
+		// Try to disable "Restore pages?" popup - although it doesn't seem to be working
+		chromeOptions.addArguments("disable-features=InfiniteSessionRestore");
+
+		// If a vpn is required, using a single Chrome profile directory to only require the user to set up their VPN once.
+		// Otherwise, use different profile per hostname so browsers don't error out from directory being in use.
+		if (vpn)
 		{
-			const chromeCapabilities: Capabilities = Capabilities.chrome();
-
-			const chromeOptions: Options = new Options();
-
-			// Try to disable "Restore pages?" popup - although it doesn't seem to be working
-			chromeOptions.addArguments("disable-features=InfiniteSessionRestore");
-
-			// If a vpn is required, using a single Chrome profile directory to only require the user to set up their VPN once.
-			// Otherwise, use different profile per hostname so browsers don't error out from directory being in use.
-			if (vpn)
-			{
-				chromeOptions.addArguments("user-data-dir=.\\webdriver-browser-profiles\\chrome-vpn\\");
-			} else
-			{
-				chromeOptions.addArguments(`user-data-dir=.\\webdriver-browser-profiles\\chrome-${startingURL.hostname}\\`);
-			}
-
-			chromeOptions.addArguments(`homepage ${startingURL.href}`);
-
-			chromeCapabilities.set("chromeOptions", chromeOptions);
-
-			this.driver = new Builder()
-				.forBrowser(browserType)
-				.setChromeOptions(chromeOptions)
-				.build();
+			chromeOptions.addArguments("user-data-dir=.\\webdriver-browser-profiles\\chrome-vpn\\");
 		} else
 		{
-			this.driver = new Builder().forBrowser(browserType)
-				.build();
+			chromeOptions.addArguments(`user-data-dir=.\\webdriver-browser-profiles\\chrome-${startingURL.hostname}\\`);
 		}
+
+		chromeOptions.addArguments(`homepage ${startingURL.href}`);
+
+		chromeCapabilities.set("chromeOptions", chromeOptions);
+
+		// Todo: Add Firefox command line argument to load the starting URL.
+		// Can then remove the "about:blank" check from loadLoginPage() in site.ts
+
+		this.driver = new Builder()
+			.forBrowser(browserType)
+			.setChromeOptions(chromeOptions)
+			.build();
+
 		logger.debug(`Browser built (${startingURL.href})`);
 	}
 

--- a/src/lib/card.ts
+++ b/src/lib/card.ts
@@ -1,49 +1,41 @@
+import { number, validate } from "@hapi/joi";
 import { DateTime } from "luxon";
 
 export type Issuer = "Bank of America" | "BarclaycardUS";
 
 export class Card
 {
-	public readonly cardholderName?: string;
-
-	public readonly cardNumber: string;
-
-	public closingDate?: DateTime;
-	public readonly description: string;
-
-	public readonly enabled: boolean;
-
-	public readonly expirationMonth?: number;
-
-	public readonly expirationYear?: number;
-
-	public readonly issuer?: Issuer;
-
-	public readonly reloadAmount: number;
-
-	public reloadTimes: number = 1;
-
-	public skip: boolean;
-
-	public transactionsFound?: boolean;
-
-	public readonly useBeforeCloseMaxDays?: number;
-
-	public constructor(card: Card)
+	public set closingDate(newClosingDate: DateTime | undefined)
 	{
-		this.cardholderName = card.cardholderName;
-		this.cardNumber = card.cardNumber;
-		this.description = card.description;
-		this.enabled = card.enabled;
-		this.expirationMonth = card.expirationMonth;
-		this.expirationYear = card.expirationYear;
-		this.reloadAmount = card.reloadAmount;
-		this.reloadTimes = card.reloadTimes;
-		this.useBeforeCloseMaxDays = card.useBeforeCloseMaxDays;
-		this.issuer = card.issuer;
-		this.closingDate = card.closingDate;
+		this._closingDate = newClosingDate;
 
-		this.skip = !card.enabled;
+		if (newClosingDate === undefined)
+		{
+			// There's no point in doing anything further
+			return;
+		}
+
+		if (this.useBeforeCloseMaxDays)
+		{
+			const today: DateTime = DateTime.local();
+
+			if (today < this.dontUseUntil)
+			{
+				// logger.info(
+				// 	`${this.friendlyReference}: Before cutoff ${this.dontUseUntil.toISODate()} (${this.useBeforeCloseMaxDays} before ${this.closingDate.toISODate()} close). Skipping card.`);
+				this.skip = true;
+			}
+			// else
+			// {
+			// 	logger.info(`${this.friendlyReference}: Now (${today.toISODate()}) is after cutoff ${this.dontUseUntil.toISODate()}`);
+			// }
+		}
+
+	}
+
+	public get closingDate(): DateTime | undefined
+	{
+		return this._closingDate;
 	}
 
 	public get closingDateAsString(): string
@@ -56,20 +48,21 @@ export class Card
 		return this.closingDate.toISODate();
 	}
 
-	public get dontUseUntil(): DateTime
+	private get dontUseUntil(): DateTime
 	{
 		let dontUseCardUntil: DateTime = DateTime.fromSeconds(0);
 
-		if (this.closingDate !== undefined) {
-
-		if (this.useBeforeCloseMaxDays)
+		if (this.closingDate !== undefined)
 		{
-			dontUseCardUntil = this.closingDate.minus({ days: this.useBeforeCloseMaxDays });
+			if (this.useBeforeCloseMaxDays)
+			{
+				dontUseCardUntil = this.closingDate.minus({ days: this.useBeforeCloseMaxDays });
+			}
 		}
-	} else
-	{
-		throw new Error(("Next statement date undefined"));
-	}
+		else
+		{
+			throw new Error(("Next statement date undefined"));
+		}
 
 		return dontUseCardUntil;
 	}
@@ -92,19 +85,31 @@ export class Card
 
 	public get friendlyReference(): string
 	{
-        return `${this.description} ending in ${this.lastFour}`;
+		return `${this.description} ending in ${this.lastFour}`;
 	}
 
 	public get lastFour(): string
 	{
-        return this.cardNumber.slice(-4);
-    }
+		return this.cardNumber.slice(-4);
+	}
+
+	public set reloadTimes(newReloadTimes: number)
+	{
+		validate(newReloadTimes, number().integer()
+			.min(0));
+		this._reloadTimes = newReloadTimes;
+	}
+
+	public get reloadTimes(): number
+	{
+		return this._reloadTimes;
+	}
 
 	public get shortDescription(): string
 	{
 		if (this.description.length > 10)
 		{
-			return `${this.description.substr(0, 4)}..${this.description.slice(-4)}${this.cardNumber.slice(-3)}`;
+			return `${this.description.substring(0, 4)}..${this.description.slice(-4)}${this.cardNumber.slice(-3)}`;
 		}
 
 		return `${this.description}${this.lastFour}`;
@@ -118,6 +123,49 @@ export class Card
 		}
 
 		return "Unknown";
+	}
+	public readonly cardholderName?: string;
+
+	public readonly cardNumber: string;
+	public readonly creditLimit?: number;
+	public readonly description: string;
+
+	public readonly enabled: boolean;
+
+	public readonly expirationMonth?: number;
+
+	public readonly expirationYear?: number;
+
+	public readonly issuer?: Issuer;
+
+	public readonly reloadAmount: number;
+
+	public skip: boolean;
+
+	public transactionsFound?: boolean;
+
+	public readonly useBeforeCloseMaxDays?: number;
+
+	private _closingDate?: DateTime;
+
+	private _reloadTimes: number = 1;
+
+	public constructor(card: Card)
+	{
+		this.cardholderName = card.cardholderName;
+		this.cardNumber = card.cardNumber;
+		this.description = card.description;
+		this.enabled = card.enabled;
+		this.expirationMonth = card.expirationMonth;
+		this.expirationYear = card.expirationYear;
+		this.reloadAmount = card.reloadAmount;
+		this.reloadTimes = card.reloadTimes;
+		this.useBeforeCloseMaxDays = card.useBeforeCloseMaxDays;
+		this.issuer = card.issuer;
+		this.closingDate = card.closingDate;
+		this.creditLimit = card.creditLimit;
+
+		this.skip = !card.enabled;
 	}
 
 	public status(): string

--- a/src/sites/amazon.ts
+++ b/src/sites/amazon.ts
@@ -1,7 +1,6 @@
 import { formatMoney } from "accounting";
 import { strict as assert } from "assert";
 import { By, Locator, ThenableWebDriver, until, WebElement } from "selenium-webdriver";
-import { URL } from "url";
 
 import { Card } from "../lib/card";
 import { Cards } from "../lib/cards";
@@ -20,10 +19,9 @@ export class Amazon extends Site implements IAmazonConfig
 
 	public constructor(amazonConfig: IAmazonConfig, completeTransactions: boolean)
 	{
-		super(amazonConfig, new URL("https://smile.amazon.com/asv/reload/"));
+		super(amazonConfig, "https://smile.amazon.com/asv/reload/");
 
 		this.completeTransactions = completeTransactions;
-		logger.info(`completeTransactions is set to ${this.completeTransactions}.`);
 
 		this.reloadDelayInSeconds =
 			typeof amazonConfig.reloadDelayInSeconds === "undefined" ? 300 : amazonConfig.reloadDelayInSeconds;
@@ -31,7 +29,6 @@ export class Amazon extends Site implements IAmazonConfig
 
 	public async reloadCards(cards: Cards): Promise<void>
 	{
-		logger.debug("Started Amazon");
 
 		// A driver alias so the code isn't *as* unwieldy
 		const driver: ThenableWebDriver = this.browser.driver;
@@ -140,15 +137,16 @@ export class Amazon extends Site implements IAmazonConfig
 		// A driver alias so the code isn't *as* unwieldy
 		const driver: ThenableWebDriver = this.browser.driver;
 
-		const reloadURL: URL = new URL(`https://smile.amazon.com/asv/reload/order?manualReload.amount=${card.reloadAmount}`);
-		await driver.get(reloadURL.href);
+		const formattedMoney: string = formatMoney(card.reloadAmount, "");
+		const reloadURL: string = `https://smile.amazon.com/asv/reload/order?manualReload.amount=${formattedMoney}`;
+		await driver.get(reloadURL);
 
 		// Enter the reload amount for this card.
 		const reloadAmount: WebElement = await driver.findElement(By.id("asv-manual-reload-amount"));
-		const formattedMoney: string = formatMoney(card.reloadAmount, "");
-		const reloadAmountElementValue = await reloadAmount.getAttribute("value");
+		const reloadAmountElementValue: string = await reloadAmount.getAttribute("value");
 		if (formattedMoney !== reloadAmountElementValue)
 		{
+			await reloadAmount.clear();
 			await reloadAmount.sendKeys(`${card.reloadAmount}`);
 		}
 

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,3 @@
+* Consider json<>class approach like http://choly.ca/post/typescript-json/
+* In browser.ts, pass the URL to the Firefox browser constructor
+* Consider using separate profiles for Firefox, similar to how is already done for Chrome

--- a/tslint/tslint.yaml
+++ b/tslint/tslint.yaml
@@ -9,7 +9,7 @@ rules:
     - tabs
   member-ordering:
     - true
-    - alphabetize: false
+    - alphabetize: true
       order: statics-first
   no-console:
     - true
@@ -31,12 +31,9 @@ rules:
   no-inferrable-types:
     - false
   one-line:
-    - true
-    - check-catch
-    - check-else
-    - check-finally
-    - check-whitespace
+    - false
   only-arrow-functions:
     - true
     - allow-named-functions
-    
+  switch-default:
+    - false


### PR DESCRIPTION
Fix: Properly format reload amount as currency in the console table
output.

Fix: The reload amount was stored internally by the app as a number, so
0.50 was stored internally as 0.5. The stored value was then sent to
Amazon as a URL parameter so that it was preloaded upon page load, but
further code checked whether the number in Amazon matched what it truly
should be, and typed the correct value if not. This resulted in an
incorrect value being entered - but not submitted - as further code
verified the value in the web interface a final time before submitting.
In Amazon.reloadCard() we now pass the number to Amazon properly
formatted as currency from the start. Although the code to type the
value shouldn’t need to run, we again clear before typing just to be
sure. Thanks to @mcgwebdesign for reporting the issue.

Update dependencies to current releases.